### PR TITLE
Add HSV color space and gamma correction support to Color class

### DIFF
--- a/Turso3D/Math/Color.cpp
+++ b/Turso3D/Math/Color.cpp
@@ -58,3 +58,62 @@ std::string Color::ToString() const
 {
     return FormatString("%g %g %g %g", r, g, b, a);
 }
+
+Color Color::FromHSV(float h, float s, float v, float a)
+{
+    while (h < 0.0f)
+		h += 360.0f;
+    while (h >= 360.0f)
+        h -= 360.0f;
+
+    s = Clamp(s, 0.0f, 1.0f);
+	v = Clamp(v, 0.0f, 1.0f);
+
+    if (s == 0.0f)
+        return Color(v, v, v, a);
+
+	float sector = h / 60.0f;
+	int i = (int)sector;
+
+	float f = sector - i;
+
+	float p = v * (1.0f - s);
+	float q = v * (1.0f - s * f);
+    float t = v * (1.0f - s * (1.0f - f));
+
+    switch (i)
+    {
+    case 0:
+        return Color(v, t, p, a);
+    case 1:
+        return Color(q, v, p, a);
+    case 2:
+        return Color(p, v, t, a);
+    case 3:
+        return Color(p, q, v, a);
+    case 4:
+        return Color(t, p, v, a);
+    default:
+        return Color(v, p, q, a);
+    }
+}
+
+Vector3 Color::ToHSV() const
+{
+    return Vector3();
+}
+
+Color Color::BlendPremultiplied(const Color& rhs) const
+{
+    return Color();
+}
+
+Color Color::GammaToLinear() const
+{
+    return Color();
+}
+
+Color Color::LinearToGamma() const
+{
+    return Color();
+}

--- a/Turso3D/Math/Color.cpp
+++ b/Turso3D/Math/Color.cpp
@@ -134,15 +134,35 @@ Vector3 Color::ToHSV() const
 
 Color Color::BlendPremultiplied(const Color& rhs) const
 {
-    return Color();
+    // Assumes 'this' is the background and 'rhs' is the foreground
+    // Both colors should be premultiplied (RGB already multiplied by alpha)
+
+    float invSrcAlpha = 1.0f - rhs.a;
+
+    return Color(
+        rhs.r + r * invSrcAlpha,
+        rhs.g + g * invSrcAlpha,
+        rhs.b + b * invSrcAlpha,
+        rhs.a + a * invSrcAlpha
+    );
 }
 
 Color Color::GammaToLinear() const
 {
-    return Color();
+    return Color(
+        r <= 0.04045f ? r / 12.92f : pow((r + 0.055f) / 1.055f, 2.4f),
+        g <= 0.04045f ? g / 12.92f : pow((g + 0.055f) / 1.055f, 2.4f),
+        b <= 0.04045f ? b / 12.92f : pow((b + 0.055f) / 1.055f, 2.4f),
+        a
+    );
 }
 
 Color Color::LinearToGamma() const
 {
-    return Color();
+    return Color(
+        r <= 0.0031308f ? r * 12.92f : 1.055f * pow(r, 1.0f / 2.4f) - 0.055f,
+        g <= 0.0031308f ? g * 12.92f : 1.055f * pow(g, 1.0f / 2.4f) - 0.055f,
+        b <= 0.0031308f ? b * 12.92f : 1.055f * pow(b, 1.0f / 2.4f) - 0.055f,
+        a
+    );
 }

--- a/Turso3D/Math/Color.cpp
+++ b/Turso3D/Math/Color.cpp
@@ -134,9 +134,7 @@ Vector3 Color::ToHSV() const
 
 Color Color::BlendPremultiplied(const Color& rhs) const
 {
-    // Assumes 'this' is the background and 'rhs' is the foreground
-    // Both colors should be premultiplied (RGB already multiplied by alpha)
-
+    // result = src + dst * (1 - src.a)
     float invSrcAlpha = 1.0f - rhs.a;
 
     return Color(

--- a/Turso3D/Math/Color.cpp
+++ b/Turso3D/Math/Color.cpp
@@ -100,7 +100,36 @@ Color Color::FromHSV(float h, float s, float v, float a)
 
 Vector3 Color::ToHSV() const
 {
-    return Vector3();
+    float min = Min(r, Min(g, b));
+    float max = Max(r, Max(g, b));
+    float delta = max - min;
+
+    float h = 0.0f;
+    float s = 0.0f;
+    float v = max;
+
+    // Calculate saturation
+    if (max > 0.0f)
+        s = delta / max;
+
+    // Calculate hue (only if color is not gray)
+    if (delta > 0.0f)
+    {
+        if (r == max)
+            h = (g - b) / delta;        // Between yellow & magenta
+        else if (g == max)
+            h = 2.0f + (b - r) / delta; // Between cyan & yellow
+        else
+            h = 4.0f + (r - g) / delta; // Between magenta & cyan
+
+        h *= 60.0f; // Convert to degrees
+
+        // Ensure hue is positive
+        if (h < 0.0f)
+            h += 360.0f;
+    }
+
+    return Vector3(h, s, v);
 }
 
 Color Color::BlendPremultiplied(const Color& rhs) const

--- a/Turso3D/Math/Color.h
+++ b/Turso3D/Math/Color.h
@@ -115,6 +115,23 @@ public:
     /// Parse from a C string. Return true on success.
     bool FromString(const char* string);
 
+	/// Convert from HSV to RGB color space.
+	static Color FromHSV(float h, float s, float v, float a = 1.0f);
+
+	/// Convert to HSV color space. Return value's x, y, and z components are hue, saturation, and value.
+    Vector3 ToHSV() const;
+
+	/// Blend this color with another one using premultiplied alpha.
+	Color BlendPremultiplied(const Color& rhs) const;
+
+	/// Return the luma (perceived brightness) of the color.
+	float Luma() const { return 0.299f * r + 0.587f * g + 0.114f * b; }
+
+	/// Convert between gamma space and linear space.
+	Color GammaToLinear() const;
+	/// Convert between linear space and gamma space.
+	Color LinearToGamma() const;
+
     /// Return RGB as a three-dimensional vector.
     Vector3 ToVector3() const { return Vector3(r, g, b); }
     /// Return RGBA as a four-dimensional vector.

--- a/Turso3D/Math/Color.h
+++ b/Turso3D/Math/Color.h
@@ -132,6 +132,15 @@ public:
 	/// Convert between linear space and gamma space.
 	Color LinearToGamma() const;
 
+    /// Convert from standard alpha to premultiplied alpha
+    Color ToPremultiplied() const { return Color(r * a, g * a, b * a, a); }
+
+    /// Convert from premultiplied alpha to standard alpha
+    Color FromPremultiplied() const
+    {
+        return a > 0.0f ? Color(r / a, g / a, b / a, a) : Color(0.0f, 0.0f, 0.0f, 0.0f);
+    }
+
     /// Return RGB as a three-dimensional vector.
     Vector3 ToVector3() const { return Vector3(r, g, b); }
     /// Return RGBA as a four-dimensional vector.

--- a/Turso3DTest/Main.cpp
+++ b/Turso3DTest/Main.cpp
@@ -29,115 +29,6 @@
 #include <SDL3/SDL.h>
 #include <tracy/Tracy.hpp>
 
-
-void TestColorFunctions()
-{
-    printf("Running Color class tests...\n");
-
-    // Test HSV round-trip conversion
-    {
-        Color orange(1.0f, 0.5f, 0.0f);
-        Vector3 hsv = orange.ToHSV();
-        Color restored = Color::FromHSV(hsv.x, hsv.y, hsv.z);
-
-        assert(fabs(orange.r - restored.r) < 0.001f);
-        assert(fabs(orange.g - restored.g) < 0.001f);
-        assert(fabs(orange.b - restored.b) < 0.001f);
-    }
-
-    // Test primary colors HSV values
-    {
-        Vector3 redHSV = Color::RED.ToHSV();
-        assert(fabs(redHSV.x - 0.0f) < 1.0f);  // Hue ~0°
-        assert(fabs(redHSV.y - 1.0f) < 0.001f); // Saturation = 1
-        assert(fabs(redHSV.z - 1.0f) < 0.001f); // Value = 1
-
-        Vector3 greenHSV = Color::GREEN.ToHSV();
-        assert(fabs(greenHSV.x - 120.0f) < 1.0f); // Hue ~120°
-
-        Vector3 blueHSV = Color::BLUE.ToHSV();
-        assert(fabs(blueHSV.x - 240.0f) < 1.0f); // Hue ~240°
-
-    }
-
-    // Test gamma conversion round-trip
-    {
-        Color srgb(0.5f, 0.5f, 0.5f);
-        Color linear = srgb.GammaToLinear();
-        Color back = linear.LinearToGamma();
-
-        assert(fabs(srgb.r - back.r) < 0.001f);
-        assert(fabs(srgb.g - back.g) < 0.001f);
-        assert(fabs(srgb.b - back.b) < 0.001f);
-    }
-
-    // Test gamma values are different
-    {
-        Color srgb(0.5f, 0.5f, 0.5f);
-        Color linear = srgb.GammaToLinear();
-
-        // Linear space value should be darker (~0.21)
-        assert(linear.r < 0.25f && linear.r > 0.20f);
-    }
-
-    // Test premultiplied alpha conversion
-    {
-        Color color(1.0f, 0.0f, 0.0f, 0.5f); // 50% red
-        Color premul = color.ToPremultiplied();
-
-        assert(fabs(premul.r - 0.5f) < 0.001f); // RGB should be halved
-        assert(fabs(premul.a - 0.5f) < 0.001f); // Alpha unchanged
-
-        Color restored = premul.FromPremultiplied();
-        assert(fabs(restored.r - 1.0f) < 0.001f);
-    }
-
-    // Test premultiplied blending
-    {
-        Color bg = Color::BLUE.ToPremultiplied();
-        Color fg = Color(1.0f, 0.0f, 0.0f, 0.5f).ToPremultiplied();
-        Color result = bg.BlendPremultiplied(fg);
-
-        // Result should have some red and some blue
-        assert(result.r > 0.0f);
-        assert(result.b > 0.0f);
-    }
-
-    // Test luma calculation
-    {
-        assert(fabs(Color::WHITE.Luma() - 1.0f) < 0.001f);
-        assert(fabs(Color::BLACK.Luma() - 0.0f) < 0.001f);
-
-        // Green should contribute most to luma (0.587 weight)
-        assert(Color::GREEN.Luma() > Color::RED.Luma());
-        assert(Color::GREEN.Luma() > Color::BLUE.Luma());
-    }
-
-    // Test FromHSV specific colors
-    {
-        Color red = Color::FromHSV(0.0f, 1.0f, 1.0f);
-        assert(fabs(red.r - 1.0f) < 0.001f);
-        assert(red.g < 0.001f);
-        assert(red.b < 0.001f);
-
-        Color yellow = Color::FromHSV(60.0f, 1.0f, 1.0f);
-        assert(fabs(yellow.r - 1.0f) < 0.001f);
-        assert(fabs(yellow.g - 1.0f) < 0.001f);
-        assert(yellow.b < 0.001f);
-
-    }
-
-    // Test grayscale in HSV (saturation = 0)
-    {
-        Color gray = Color::FromHSV(180.0f, 0.0f, 0.5f);
-        assert(fabs(gray.r - 0.5f) < 0.001f);
-        assert(fabs(gray.g - 0.5f) < 0.001f);
-        assert(fabs(gray.b - 0.5f) < 0.001f);
-    }
-
-    printf("All Color class tests passed!\n\n");
-}
-
 std::vector<StaticModel*> rotatingObjects;
 std::vector<AnimatedModel*> animatingObjects;
 
@@ -326,8 +217,6 @@ void CreateScene(Scene* scene, Camera* camera, int preset)
 
 int ApplicationMain(const std::vector<std::string>& arguments)
 {
-	TestColorFunctions();
-
     bool useThreads = true;
 
     if (arguments.size() > 1 && arguments[1].find("nothreads") != std::string::npos)

--- a/Turso3DTest/Main.cpp
+++ b/Turso3DTest/Main.cpp
@@ -29,6 +29,115 @@
 #include <SDL3/SDL.h>
 #include <tracy/Tracy.hpp>
 
+
+void TestColorFunctions()
+{
+    printf("Running Color class tests...\n");
+
+    // Test HSV round-trip conversion
+    {
+        Color orange(1.0f, 0.5f, 0.0f);
+        Vector3 hsv = orange.ToHSV();
+        Color restored = Color::FromHSV(hsv.x, hsv.y, hsv.z);
+
+        assert(fabs(orange.r - restored.r) < 0.001f);
+        assert(fabs(orange.g - restored.g) < 0.001f);
+        assert(fabs(orange.b - restored.b) < 0.001f);
+    }
+
+    // Test primary colors HSV values
+    {
+        Vector3 redHSV = Color::RED.ToHSV();
+        assert(fabs(redHSV.x - 0.0f) < 1.0f);  // Hue ~0°
+        assert(fabs(redHSV.y - 1.0f) < 0.001f); // Saturation = 1
+        assert(fabs(redHSV.z - 1.0f) < 0.001f); // Value = 1
+
+        Vector3 greenHSV = Color::GREEN.ToHSV();
+        assert(fabs(greenHSV.x - 120.0f) < 1.0f); // Hue ~120°
+
+        Vector3 blueHSV = Color::BLUE.ToHSV();
+        assert(fabs(blueHSV.x - 240.0f) < 1.0f); // Hue ~240°
+
+    }
+
+    // Test gamma conversion round-trip
+    {
+        Color srgb(0.5f, 0.5f, 0.5f);
+        Color linear = srgb.GammaToLinear();
+        Color back = linear.LinearToGamma();
+
+        assert(fabs(srgb.r - back.r) < 0.001f);
+        assert(fabs(srgb.g - back.g) < 0.001f);
+        assert(fabs(srgb.b - back.b) < 0.001f);
+    }
+
+    // Test gamma values are different
+    {
+        Color srgb(0.5f, 0.5f, 0.5f);
+        Color linear = srgb.GammaToLinear();
+
+        // Linear space value should be darker (~0.21)
+        assert(linear.r < 0.25f && linear.r > 0.20f);
+    }
+
+    // Test premultiplied alpha conversion
+    {
+        Color color(1.0f, 0.0f, 0.0f, 0.5f); // 50% red
+        Color premul = color.ToPremultiplied();
+
+        assert(fabs(premul.r - 0.5f) < 0.001f); // RGB should be halved
+        assert(fabs(premul.a - 0.5f) < 0.001f); // Alpha unchanged
+
+        Color restored = premul.FromPremultiplied();
+        assert(fabs(restored.r - 1.0f) < 0.001f);
+    }
+
+    // Test premultiplied blending
+    {
+        Color bg = Color::BLUE.ToPremultiplied();
+        Color fg = Color(1.0f, 0.0f, 0.0f, 0.5f).ToPremultiplied();
+        Color result = bg.BlendPremultiplied(fg);
+
+        // Result should have some red and some blue
+        assert(result.r > 0.0f);
+        assert(result.b > 0.0f);
+    }
+
+    // Test luma calculation
+    {
+        assert(fabs(Color::WHITE.Luma() - 1.0f) < 0.001f);
+        assert(fabs(Color::BLACK.Luma() - 0.0f) < 0.001f);
+
+        // Green should contribute most to luma (0.587 weight)
+        assert(Color::GREEN.Luma() > Color::RED.Luma());
+        assert(Color::GREEN.Luma() > Color::BLUE.Luma());
+    }
+
+    // Test FromHSV specific colors
+    {
+        Color red = Color::FromHSV(0.0f, 1.0f, 1.0f);
+        assert(fabs(red.r - 1.0f) < 0.001f);
+        assert(red.g < 0.001f);
+        assert(red.b < 0.001f);
+
+        Color yellow = Color::FromHSV(60.0f, 1.0f, 1.0f);
+        assert(fabs(yellow.r - 1.0f) < 0.001f);
+        assert(fabs(yellow.g - 1.0f) < 0.001f);
+        assert(yellow.b < 0.001f);
+
+    }
+
+    // Test grayscale in HSV (saturation = 0)
+    {
+        Color gray = Color::FromHSV(180.0f, 0.0f, 0.5f);
+        assert(fabs(gray.r - 0.5f) < 0.001f);
+        assert(fabs(gray.g - 0.5f) < 0.001f);
+        assert(fabs(gray.b - 0.5f) < 0.001f);
+    }
+
+    printf("All Color class tests passed!\n\n");
+}
+
 std::vector<StaticModel*> rotatingObjects;
 std::vector<AnimatedModel*> animatingObjects;
 
@@ -217,6 +326,8 @@ void CreateScene(Scene* scene, Camera* camera, int preset)
 
 int ApplicationMain(const std::vector<std::string>& arguments)
 {
+	TestColorFunctions();
+
     bool useThreads = true;
 
     if (arguments.size() > 1 && arguments[1].find("nothreads") != std::string::npos)


### PR DESCRIPTION
This PR extends the `Color` class with commonly needed color manipulation functions:

### Added functionality:
- **HSV conversion**: `FromHSV()` and `ToHSV()` for hue/saturation/value color space
- **Gamma correction**: `GammaToLinear()` and `LinearToGamma()` using sRGB standard
- **Premultiplied alpha**: `ToPremultiplied()`, `FromPremultiplied()`, and `BlendPremultiplied()`
- **Luma calculation**: `Luma()` for perceived brightness using ITU-R BT.601 weights

### Testing:
Added runtime tests in Turso3DTest to verify:
- HSV round-trip conversions
- Gamma correction accuracy
- Premultiplied alpha blending
- Luma calculations

These functions are useful for color manipulation in shaders, UI rendering, and particle effects.

-- I am not sure if the runtime tests are ok or how to handle them. Please tell me how to handle those